### PR TITLE
Add state clearing function

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -81,6 +81,8 @@ func (f *finder) initFinder(items []string, matched []matching.Matched, opts []O
 	}
 	f.opt = &opt
 
+	f.state = state{}
+
 	if opt.multi {
 		f.state.selection = map[int]int{}
 	}


### PR DESCRIPTION
Called upon finder init to avoid residual state from previous run.

Resolves https://github.com/ktr0731/go-fuzzyfinder/issues/3

This is one way to resolve it. Another would be to create a new state struct entirely—happy to take direction on that—or otherwise, best place to put the `clear()`