### PR TITLE
Set prompt color

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -121,7 +121,7 @@ func (f *finder) _draw() {
 	// prompt line
 	var promptLinePad int
 	for _, r := range []rune(f.opt.promptString) {
-		f.term.setCell(promptLinePad, height-1, r, termbox.ColorBlue, termbox.ColorDefault)
+		f.term.setCell(promptLinePad, height-1, r, f.opt.promptColor, termbox.ColorDefault)
 		promptLinePad++
 	}
 	var r rune

--- a/option.go
+++ b/option.go
@@ -1,11 +1,16 @@
 package fuzzyfinder
 
+import (
+	"github.com/gdamore/tcell/termbox"
+)
+
 type opt struct {
 	mode         mode
 	previewFunc  func(i, width, height int) string
 	multi        bool
 	hotReload    bool
 	promptString string
+	promptColor  termbox.Attribute
 }
 
 type mode int
@@ -23,6 +28,7 @@ const (
 
 var defaultOption = opt{
 	promptString: "> ",
+	promptColor:  termbox.ColorBlue,
 }
 
 // Option represents available fuzzy-finding options.
@@ -61,6 +67,13 @@ func WithHotReload() Option {
 func WithPromptString(s string) Option {
 	return func(o *opt) {
 		o.promptString = s
+	}
+}
+
+// WithPromptString changes the prompt string. The default value is "> ".
+func WithPromptColor(c termbox.Attribute) Option {
+	return func(o *opt) {
+		o.promptColor = c
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -70,7 +70,7 @@ func WithPromptString(s string) Option {
 	}
 }
 
-// WithPromptString changes the prompt string. The default value is "> ".
+// WithPromptColor changes the prompt color. The default value is termbox.ColorBlue.
 func WithPromptColor(c termbox.Attribute) Option {
 	return func(o *opt) {
 		o.promptColor = c


### PR DESCRIPTION
This PR adds support for setting Prompt Color to a custom value. I added it because getting the “blue” color to be readable on my dark-background terminal was an exercise in futility.