### PR TITLE
Add option to use custom item view

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -163,7 +163,13 @@ func (f *finder) _draw() {
 
 		var posIdx int
 		w := 2
-		for j, r := range []rune(f.state.items[m.Idx]) {
+		var item string
+		if f.opt.itemViewFunc != nil {
+			item = f.opt.itemViewFunc(m.Idx)
+		} else {
+			item = f.state.items[m.Idx]
+		}
+		for j, r := range []rune(item) {
 			fg := termbox.ColorDefault
 			bg := termbox.ColorDefault
 			// Highlight selected strings.

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package fuzzyfinder
 type opt struct {
 	mode         mode
 	previewFunc  func(i, width, height int) string
+	itemViewFunc func(i int) string
 	multi        bool
 	hotReload    bool
 	promptString string
@@ -61,6 +62,15 @@ func WithHotReload() Option {
 func WithPromptString(s string) Option {
 	return func(o *opt) {
 		o.promptString = s
+	}
+}
+
+// WithItemView allows to add additional information to item entries
+func WithItemView(f func(i int) string) Option {
+	return func(o *opt) {
+		{
+			o.itemViewFunc = f
+		}
 	}
 }
 


### PR DESCRIPTION
**Summary**

This change adds another option in option.go
file that allows user to render item views (think descriptions/titles).

This API is similar to the concept of post processing in
fzf: https://github.com/junegunn/fzf/wiki/Examples-(completion)

However, this library already provides means to postprocess items
via itemFunc. All that's left to replicate fzf functionality is
the above mentioned change that allows to process items in order
to extract view from them.