### PR TITLE
sort/maintain-list-order: maintain original order when when scores are tied

### DIFF
--- a/matching/matching.go
+++ b/matching/matching.go
@@ -57,9 +57,8 @@ func FindAll(in string, slice []string, opts ...Option) []Matched {
 	sort.Slice(m, func(i, j int) bool {
 		if m[i].score == m[j].score {
 			return m[i].Idx > m[j].Idx
-		} else {
-			return m[i].score > m[j].score
 		}
+		return m[i].score > m[j].score
 	})
 	return m
 }

--- a/matching/matching.go
+++ b/matching/matching.go
@@ -55,7 +55,11 @@ func FindAll(in string, slice []string, opts ...Option) []Matched {
 	}
 	m := match(in, slice, opt)
 	sort.Slice(m, func(i, j int) bool {
-		return m[i].score > m[j].score
+		if m[i].score == m[j].score {
+			return m[i].Idx > m[j].Idx
+		} else {
+			return m[i].score > m[j].score
+		}
 	})
 	return m
 }


### PR DESCRIPTION
When multiple slices have the same SmithWaterman score the order in which they appear are not preserved, this PR improves the sorting function to keep the original order