### PR TITLE
allow setting tcell prompt color

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -166,7 +166,7 @@ func (f *finder) _draw() {
 
 	for _, r := range f.opt.promptString {
 		style := tcell.StyleDefault.
-			Foreground(tcell.ColorBlue).
+			Foreground(f.opt.promptColor).
 			Background(tcell.ColorDefault)
 
 		f.term.SetContent(promptLinePad, maxHeight-1, r, nil, style)

--- a/option.go
+++ b/option.go
@@ -3,6 +3,8 @@ package fuzzyfinder
 import (
 	"context"
 	"sync"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 type opt struct {
@@ -12,6 +14,7 @@ type opt struct {
 	hotReload     bool
 	hotReloadLock sync.Locker
 	promptString  string
+	promptColor   tcell.Color
 	header        string
 	beginAtTop    bool
 	context       context.Context
@@ -34,6 +37,7 @@ const (
 
 var defaultOption = opt{
 	promptString:  "> ",
+	promptColor:   tcell.ColorBlue,
 	hotReloadLock: &sync.Mutex{}, // this won't resolve the race condition but avoid nil panic
 }
 
@@ -106,6 +110,13 @@ func WithCursorPosition(position cursorPosition) Option {
 func WithPromptString(s string) Option {
 	return func(o *opt) {
 		o.promptString = s
+	}
+}
+
+// WithPromptColor changes the prompt color. The default color is blue.
+func WithPromptColor(c tcell.Color) Option {
+	return func(o *opt) {
+		o.promptColor = c
 	}
 }
 


### PR DESCRIPTION
I'd originally opened this as #13 ages ago, back before this library updated to tcell.

I picked it up again while updating dependencies in my fork.

In the original PR, we'd talked about encapsulating the set of colors in go-fuzzyfinder to avoid leaking the underlying terminal library through to the option struct. Looking at tcell, I'm not sure I see a way to cleanly do that. Because tcell is basically taking a uint64, and is itself already supporting any standard / xterm color, the set of colors it accepts is massive. I could make the function take a uint64 and cast it, but that doesn't actually feel cleaner: I'd be leaking tcell's methodology but in a less clear way.

Curious for your thoughts.