### PR TITLE
Fix scrolling when header is present

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -490,6 +490,11 @@ func (f *finder) readKey(ctx context.Context) error {
 	// Max number of lines to scroll by using PgUp and PgDn
 	var pageScrollBy = screenHeight - 3
 
+	occupiedLines := 2
+	if len(f.opt.header) != 0 {
+		occupiedLines++
+	}
+
 	switch e := e.(type) {
 	case *tcell.EventKey:
 		switch e.Key() {
@@ -554,7 +559,7 @@ func (f *finder) readKey(ctx context.Context) error {
 			if f.state.y+1 < matchedLinesCount {
 				f.state.y++
 			}
-			if f.state.cursorY+1 < min(matchedLinesCount, screenHeight-2) {
+			if f.state.cursorY+1 < min(matchedLinesCount, screenHeight-occupiedLines) {
 				f.state.cursorY++
 			}
 		case tcell.KeyDown, tcell.KeyCtrlJ, tcell.KeyCtrlN:
@@ -607,7 +612,7 @@ func (f *finder) readKey(ctx context.Context) error {
 		f.term.Clear()
 
 		width, height := f.term.Size()
-		itemAreaHeight := height - 2 - 1
+		itemAreaHeight := height - occupiedLines - 1
 		if itemAreaHeight >= 0 && f.state.cursorY > itemAreaHeight {
 			f.state.cursorY = itemAreaHeight
 		}


### PR DESCRIPTION
## Reproducing the bug

- Apply the following patch on a clean `master`:
```diff
diff --git a/example/cli/main.go b/example/cli/main.go
index 7b9b8d2..3baf694 100644
--- a/example/cli/main.go
+++ b/example/cli/main.go
@@ -29,7 +29,8 @@ func main() {
                slice,
                func(i int) string {
                        return slice[i]
-               })
+               },
+               fuzzyfinder.WithHeader("header"))
        if err != nil {
                log.Fatal(err)
        }
```

- Run `printf 'a\nb\nc\nd\ne\nf' | go run example/cli/main.go`.
- Reduce the height of the terminal such that not all items fit on the screen.
- Scroll all the way up in the list and notice how the cursor is one position above what you can actually see. Demo:

https://github.com/ktr0731/go-fuzzyfinder/assets/172263548/2c030a0c-0fd3-410f-9aee-388ea0a66aa9

## Fixing the bug

If the prompt has a header, increment the number of already-occupied lines (the other ones being the line with the search input, and the line with the result count).