### PR TITLE
fix: use rune count for cursor position in WithQuery for multibyte strings

### DIFF
--- a/fuzzyfinder.go
+++ b/fuzzyfinder.go
@@ -160,7 +160,7 @@ func (f *finder) initFinder(items []string, matched []matching.Matched, opt opt)
 	if opt.query != "" {
 		f.state.input = []rune(opt.query)
 		f.state.cursorX = runewidth.StringWidth(opt.query)
-		f.state.x = len(opt.query)
+		f.state.x = len(f.state.input)
 		f.filter()
 	}
 

--- a/fuzzyfinder_test.go
+++ b/fuzzyfinder_test.go
@@ -517,6 +517,26 @@ func TestFind_WithQuery(t *testing.T) {
 			return res
 		})
 	})
+
+	t.Run("multibyte initial query does not panic on Left", func(t *testing.T) {
+		t.Parallel()
+		things2 := []string{"ほげ", "ふが"}
+		thingFunc2 := func(i int) string { return things2[i] }
+		f, term := fuzzyfinder.NewWithMockedTerminal()
+		// WithQuery("ほげ") sets cursor at rune index 2; pressing Left must not panic.
+		ev := keys(
+			input{tcell.KeyLeft, rune(tcell.KeyLeft), tcell.ModNone},
+			input{tcell.KeyEnter, rune(tcell.KeyEnter), tcell.ModNone},
+		)
+		term.SetEventsV2(ev...)
+		idx, err := f.Find(things2, thingFunc2, fuzzyfinder.WithQuery("ほげ"))
+		if err != nil {
+			t.Fatalf("Find must not return an error, but got '%s'", err)
+		}
+		if idx != 0 {
+			t.Errorf("expected index 0, got %d", idx)
+		}
+	})
 }
 
 func TestFind_WithSelectOne(t *testing.T) {


### PR DESCRIPTION
Fixes #210.

`WithQuery` sets `state.x` (the cursor rune-index) via `len(opt.query)`, which
returns the **byte** count of the string. For multibyte characters like Japanese
(`"ほげ"`: 2 runes, 6 bytes) this makes `state.x` far exceed
`len(state.input)`.  On the next keypress that reads `state.input[state.x-1]`
(e.g. Left, Backspace) the runtime panics with _index out of range_.

The fix uses `len(f.state.input)` (already populated as `[]rune(opt.query)`
on the line above) which is always the correct rune count.

**Verification**

- Reproducer: `WithQuery("ほげ")` + press any cursor-movement key -> panic.
- Regression test added: presses Left with a multibyte initial query; passes
  with the fix, panics without it.
- `go test -race ./...` green.
- `go vet ./...` clean.